### PR TITLE
商品詳細表示機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Things you may want to cover:
 | user_id                    | integer | foreign_key: true |
 | category_id                | integer | null: false       |
 | product_status_id          | integer | null: false       |
-| shipping_charges_id        | integer | null: false       |
+| shipping_charge_id         | integer | null: false       |
 | prefecture_id              | integer | null: false       |
 | estimated_shipping_date_id | integer | null: false       |
 | price                      | integer | null: false       |

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
 
   def index
-    @products = Product.all.order("created_at DESC")
+    @products = Product.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,6 +18,10 @@ class ProductsController < ApplicationController
     end
   end
 
+  def show
+    @product = Product.find(params[:id])
+  end
+
   private
 
   def move_to_index
@@ -25,7 +29,7 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.require(:product).permit(:image, :name, :explanation, :category_id, :product_status_id, :shipping_charges_id, \
+    params.require(:product).permit(:image, :name, :explanation, :category_id, :product_status_id, :shipping_charge_id, \
                                     :prefecture_id, :estimated_shipping_date_id, :price).merge(user_id: current_user.id)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -15,5 +15,9 @@ class Product < ApplicationRecord
   # 画像保存のアソシエーション
   has_one_attached :image
   # アクティブハッシュのアソシエーション
-  belongs_to_active_hash :category, :product_status, :shipping_charge, :prefecture, :estimated_shipping_date
+  belongs_to_active_hash :category
+  belongs_to_active_hash :product_status
+  belongs_to_active_hash :shipping_charge
+  belongs_to_active_hash :prefecture
+  belongs_to_active_hash :estimated_shipping_date
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,7 +5,7 @@ class Product < ApplicationRecord
   validates :image, :name, :explanation, presence: true
   validates :price, presence: true, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
   # アクティブハッシュのバリデーション
-  validates :category_id, :product_status_id, :shipping_charges_id, :prefecture_id, :estimated_shipping_date_id,
+  validates :category_id, :product_status_id, :shipping_charge_id, :prefecture_id, :estimated_shipping_date_id,
             numericality: { other_than: 1, message: 'を選択してください' }
 
   # アソシエーション
@@ -15,9 +15,5 @@ class Product < ApplicationRecord
   # 画像保存のアソシエーション
   has_one_attached :image
   # アクティブハッシュのアソシエーション
-  belongs_to_active_hash :category
-  belongs_to_active_hash :product_status
-  belongs_to_active_hash :shipping_charge
-  belongs_to_active_hash :prefecture
-  belongs_to_active_hash :estimated_shipping_date
+  belongs_to_active_hash :category, :product_status, :shipping_charge, :prefecture, :estimated_shipping_date
 end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
       <% @products.each do |product| %>
         <li class='list'>
-          <%= link_to products_path(product.id), method: :get do %>
+          <%= link_to product_path(product.id), method: :get do %>
           <div class='item-img-content'>
             <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -69,7 +69,7 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_charges_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,19 +4,21 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image ,class:"item-box-img" %>
+
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <%# <div class='sold-out'> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥ #{@product.price.to_s(:delimited, delimiter: ',')}" %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -42,27 +44,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.product_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.estimated_shipping_date.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -25,17 +25,17 @@
       </span>
     </div>
 
-    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @product.user_id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% else %>
+        <%# 商品が売れている場合のみ、表示させない処理をあとで追加 %>
+          <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# 商品が売れている場合のみ、表示させない処理をあとで追加 %>
+      <% end %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -103,7 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,7 +14,7 @@ ja:
         explanation:                商品の説明
         category_id:                カテゴリー
         product_status_id:          商品の状態
-        shipping_charge_id:        配送料の負担
+        shipping_charge_id:         配送料の負担
         prefecture_id:              発送元の地域
         estimated_shipping_date_id: 発送までの日数
         price:                      価格

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,7 +14,7 @@ ja:
         explanation:                商品の説明
         category_id:                カテゴリー
         product_status_id:          商品の状態
-        shipping_charges_id:        配送料の負担
+        shipping_charge_id:        配送料の負担
         prefecture_id:              発送元の地域
         estimated_shipping_date_id: 発送までの日数
         price:                      価格

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "products#index"
-  resources :products, only: [:index, :new, :create]
+  resources :products, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20200902033135_create_products.rb
+++ b/db/migrate/20200902033135_create_products.rb
@@ -6,7 +6,7 @@ class CreateProducts < ActiveRecord::Migration[6.0]
       t.integer :user_id,                    foreign_key: true
       t.integer :category_id,                null: false
       t.integer :product_status_id,          null: false
-      t.integer :shipping_charges_id,        null: false
+      t.integer :shipping_charge_id,         null: false
       t.integer :prefecture_id,              null: false
       t.integer :estimated_shipping_date_id, null: false
       t.integer :price,                      null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2020_09_10_103640) do
     t.integer "user_id"
     t.integer "category_id", null: false
     t.integer "product_status_id", null: false
-    t.integer "shipping_charges_id", null: false
+    t.integer "shipping_charge_id", null: false
     t.integer "prefecture_id", null: false
     t.integer "estimated_shipping_date_id", null: false
     t.integer "price", null: false


### PR DESCRIPTION
修正を行いましたので、以下の通りレビューをお願い致します。
ご不明点がありましたらご連絡ください。

## ルーティング
### config/routes.rb
resourcesメソッドのonlyオプションに”show”を追加

## コントローラ
### app/controllers/products_controller.rb
showアクションを追加
product_paramsメソッドの”shipping_charge_id”を複数形から単数形に修正

## モデル
app/models/product.rb
バリデーションとアソシエーションのshipping_chargeを複数形から単数形に修正

## ビュー
### app/views/products/new.html.erb
72行目の“shipping_charge_id”の複数形を単数形に修正

### app/views/products/show.html.erb
商品の詳細が画面に表示されるよう修正
ログインの有無、および自己の出品物かどうかで「編集・削除」「購入」ボタンの有無が切り替わるよう修正

## その他
### db/migrate/20200902033135_create_products.rb
“shipping_charge_id”の複数形を単数形に修正

### config/locales/ja.yml
“shipping_charge_id”の複数形を単数形に修正

## 挙動確認
### 未ログイン時の詳細画面
https://gyazo.com/5088cb79e7d93f36385edae1af4d79d9

### ログインユーザと出品者が異なっている場合の詳細画面
https://gyazo.com/a50a8c7901c6cf21a00334a7013793fb

### ログインユーザと出品者が一致している場合の詳細画面
https://gyazo.com/d06981ef0d5bfbe310bb3d8e61127e19