### PR TITLE
商品一覧において、商品が購入済みだった場合、Sold outを表示する処理を133行目に追加

### DIFF
--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -130,13 +130,11 @@
           <%= link_to product_path(product.id), method: :get do %>
           <div class='item-img-content'>
             <%= image_tag product.image, class: "item-img" %>
-
-            <%# 商品が売れていればsold outの表示 %>
-              <%# <div class='sold-out'> %>
-                <%# <span>Sold Out!!</span> %>
-              <%# </div> %>
-            <%# //商品が売れていればsold outの表示 %>
-
+            <% if product.order.present? %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+            <% end %>
           </div>
           <div class='item-info'>
             <h3 class='item-name'>


### PR DESCRIPTION
修正を行いましたので、以下の通りレビューをお願い致します。
ご不明点がありましたらご連絡ください。

## ビュー
### app/views/products/index.html.erb
商品一覧において、商品が購入済みだった場合、Sold outを表示する処理を133行目に追加

## 挙動確認
### orderテーブルにデータが存在する（product_idが存在する）商品は商品一覧表示画面において、画像上にSold outが表示される
https://gyazo.com/e9b02d022c4d1c8c43a657ee859e67fa

orderテーブルの状態：https://gyazo.com/5989fb3be7a5d3065231263d9a68884e
orderに対応するproductテーブルの状態：https://gyazo.com/edbadfd7b7f161270f541da5b6f66215

※本レビュー以外の商品一覧表示機能のレビューは以下の通りです
https://github.com/SSaeki-jp/furima-29261/pull/5